### PR TITLE
Add OBKiddos Minecraft servers

### DIFF
--- a/beets/docker-compose.yaml
+++ b/beets/docker-compose.yaml
@@ -1,12 +1,11 @@
-# docker compose up
 version: "3.9"
 services:
   beets:
     build: .
     environment:
-      - PUID=1000
-      - PGID=1000
-      - BEETSDIR=.
+      PUID: 1000
+      PGID: 1000
+      BEETSDIR: .
     volumes:
       - ./volume:/volume
     ports:

--- a/lidarr/docker-compose.yaml
+++ b/lidarr/docker-compose.yaml
@@ -6,10 +6,10 @@ services:
     ports:
       - "8686:8686"
     environment:
-      - PUID=1000
-      - PGID=1000
-      - UMASK=002
-      - TZ=Etc/UTC
+      PUID: 1000
+      PGID: 1000
+      UMASK: 002
+      TZ: Etc/UTC
     volumes:
       - ./lidarr-volume:/config
       - ./downloads:/downloads
@@ -20,9 +20,9 @@ services:
     ports:
       - "9117:9117"
     environment:
-      - PUID=1000
-      - PGID=1000
-      - UMASK=002
-      - TZ=Etc/UTC
+      PUID: 1000
+      PGID: 1000
+      UMASK: 002
+      TZ: Etc/UTC
     volumes:
       - ./jackett-volume:/config

--- a/minecraft-server-1/README.md
+++ b/minecraft-server-1/README.md
@@ -1,0 +1,3 @@
+# Minecraft Server 1
+
+This is the first shared server the OB Kiddos made. This is the one with the large basement and the oversized Iron farm.

--- a/minecraft-server-1/docker-compose.yaml
+++ b/minecraft-server-1/docker-compose.yaml
@@ -1,0 +1,34 @@
+version: "3.9"
+services:
+  minecraft-server-3:
+    image: itzg/minecraft-server
+    environment:
+      ENABLE_RCON: "true"
+      OPS: "0a499d9d-e542-4394-ae92-e5646580a310"
+      DIFFICULTY: "normal"
+      MOTD: "Moo's Pasture - Moo, Moo, Bitch"
+      OVERRIDE_SERVER_PROPERTIES: "TRUE"
+      ENFORCE_WHITELIST: "TRUE"
+      WHITELIST: "0a499d9d-e542-4394-ae92-e5646580a310,786cf52f-eed1-43e7-a394-9ae12cdd172e,dfdec815-5a93-4a31-b4ea-b1c227a05006,754c94dc-2237-4def-891f-b75381c5df20"
+      PATH: "/opt/java/openjdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      LANG: "en_US.UTF-8"
+      LANGUAGE: "en_US:en"
+      LC_ALL: "en_US.UTF-8"
+      JAVA_VERSION: "jdk-17.0.3+7"
+      JAVA_HOME: "/opt/java/openjdk"
+      TYPE: "VANILLA"
+      VERSION: "LATEST"
+      EULA: "TRUE"
+      UID: "1000"
+      GID: "1000"
+      MEMORY: "8G"
+    volumes:
+      - /volume2/docker/minecraft-server-1:/data
+    ports:
+      - 25565:25565
+      - 25575:25575
+    restart: unless-stopped
+    # NOTE: This is deprecated, we'll need to update this to 'deploy' once we can update
+    # the docker version on the Synology NAS
+    # https://docs.docker.com/compose/compose-file/deploy/#memory
+    mem_limit: 8G

--- a/minecraft-server-1/docker_run.sh
+++ b/minecraft-server-1/docker_run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if docker compose build --parallel ; then
+    docker compose up --remove-orphans --detach
+else
+    echo "Docker compose build failed"
+fi

--- a/minecraft-server-3/README.md
+++ b/minecraft-server-3/README.md
@@ -1,0 +1,3 @@
+# Minecraft Server 3
+
+This is the mountain-based village server

--- a/minecraft-server-3/docker-compose.yaml
+++ b/minecraft-server-3/docker-compose.yaml
@@ -1,0 +1,34 @@
+version: "3.9"
+services:
+  minecraft-server-3:
+    image: itzg/minecraft-server
+    environment:
+      ENABLE_RCON: "true"
+      OPS: "0a499d9d-e542-4394-ae92-e5646580a310"
+      DIFFICULTY: "normal"
+      MOTD: "Moo's Pasture - Moo, Moo, Bitch"
+      OVERRIDE_SERVER_PROPERTIES: "TRUE"
+      ENFORCE_WHITELIST: "TRUE"
+      WHITELIST: "0a499d9d-e542-4394-ae92-e5646580a310,786cf52f-eed1-43e7-a394-9ae12cdd172e,dfdec815-5a93-4a31-b4ea-b1c227a05006,754c94dc-2237-4def-891f-b75381c5df20"
+      PATH: "/opt/java/openjdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      LANG: "en_US.UTF-8"
+      LANGUAGE: "en_US:en"
+      LC_ALL: "en_US.UTF-8"
+      JAVA_VERSION: "jdk-17.0.3+7"
+      JAVA_HOME: "/opt/java/openjdk"
+      TYPE: "VANILLA"
+      VERSION: "LATEST"
+      EULA: "TRUE"
+      UID: "1000"
+      GID: "1000"
+      MEMORY: "8G"
+    volumes:
+      - /volume2/docker/minecraft-server-3:/data
+    ports:
+      - 25565:25565
+      - 25575:25575
+    restart: unless-stopped
+    # NOTE: This is deprecated, we'll need to update this to 'deploy' once we can update
+    # the docker version on the Synology NAS
+    # https://docs.docker.com/compose/compose-file/deploy/#memory
+    mem_limit: 8G

--- a/minecraft-server-3/docker_run.sh
+++ b/minecraft-server-3/docker_run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if docker compose build --parallel ; then
+    docker compose up --remove-orphans --detach
+else
+    echo "Docker compose build failed"
+fi

--- a/qBittorrent/config/config/qBittorrent.conf
+++ b/qBittorrent/config/config/qBittorrent.conf
@@ -21,6 +21,7 @@ AutoDeleteAddedTorrentFile=Never
 MigrationVersion=2
 
 [Network]
+Cookies=@Invalid()
 Proxy\OnlyForTorrents=false
 
 [Preferences]
@@ -45,7 +46,6 @@ MailNotification\smtp_server=smtp.changeme.com
 MailNotification\username=
 WebUI\Address=*
 WebUI\AlternativeUIEnabled=false
-WebUI\AuthSubnetWhitelist=@Invalid()
 WebUI\AuthSubnetWhitelistEnabled=false
 WebUI\BanDuration=3600
 WebUI\CSRFProtection=true

--- a/qBittorrent/docker-compose.yaml
+++ b/qBittorrent/docker-compose.yaml
@@ -6,12 +6,12 @@ services:
       - "8080:8080"
     environment:
       # NOTE: RED_API_KEY is populated from a .env file
-      - RED_API_KEY=${RED_API_KEY}
-      - ORIGIN_TRACKER=red
-      - PUID=1000
-      - PGID=1000
-      - UMASK=002
-      - TZ=Etc/UTC
+      RED_API_KEY: ${RED_API_KEY}
+      ORIGIN_TRACKER: red
+      PUID: 1000
+      PGID: 1000
+      UMASK: 002
+      TZ: Etc/UTC
     volumes:
       - ./config:/config
       # Loading in the post-download scripts

--- a/run.sh
+++ b/run.sh
@@ -8,15 +8,17 @@ echo "Starting up the docker container for the home setup..."
 if [ "$RUN_TYPE" = "local" ]; then
     echo "Starting up with the 'local' configuration"
     source config/local.sh
+    RUN_ARGS="--detach"
 elif [ "$RUN_TYPE" = "nas" ]; then
     echo "Starting up with the 'nas' configuration"
     source config/nas.sh
+    RUN_ARGS="--detach"
 else
     echo "Run type '$RUN_TYPE' not supported. Supported types are 'local' and 'nas'. Exiting..."
 fi
 
 if docker-compose build ; then
-    docker-compose up --remove-orphans
+    docker-compose up --remove-orphans ${RUN_ARGS}
 else
     echo "Docker compose build failed"
 fi


### PR DESCRIPTION
Since this repository is moving towards configuring and modifying Docker on the Synology NAS more directly, it doesn't make much sense to keep the Minecraft servers defined exclusively in the Synology system.

1. The Synology Docker Package UI is limited and is missing critical functionality
2. The Synology Docker Package UI might break if the Synology NAS docker version is updated/changed
3. The Synology Docker Package UI might not maintain the Minecraft server configuration if the docker system is pruned on the NAS
